### PR TITLE
Revert "Published time should be user's local time #1170"

### DIFF
--- a/activity_stream.py
+++ b/activity_stream.py
@@ -98,9 +98,7 @@ class Activity(ModelSQL, ModelView):
         if not self.search([('id', '=', activity.id)], count=True):
             return None
         response_json = {
-            "published": request.nereid_user.aslocaltime(
-                activity.create_date
-            ).isoformat(),
+            "published": activity.create_date.isoformat(),
             "actor": nereid_user_obj._json(activity.actor),
             "verb": activity.verb,
         }


### PR DESCRIPTION
- This reverts commit 2ae42a83ba6a54b4c23b05c0b43faf18204c577b.
- The serialized activity stream is cached for performance by
  other modules. If the timezone is cached in any user's local
  timezone, it is even more difficult to convert to the current
  user's timezone without additional plugins.
